### PR TITLE
location_descriptor: Fix compare operator for single stepping

### DIFF
--- a/src/frontend/A32/location_descriptor.h
+++ b/src/frontend/A32/location_descriptor.h
@@ -55,7 +55,7 @@ public:
     bool SingleStepping() const { return single_stepping; }
 
     bool operator == (const LocationDescriptor& o) const {
-        return std::tie(arm_pc, cpsr, fpscr, single_stepping) == std::tie(o.arm_pc, o.cpsr, o.fpscr, single_stepping);
+        return std::tie(arm_pc, cpsr, fpscr, single_stepping) == std::tie(o.arm_pc, o.cpsr, o.fpscr, o.single_stepping);
     }
 
     bool operator != (const LocationDescriptor& o) const {

--- a/src/frontend/A64/location_descriptor.h
+++ b/src/frontend/A64/location_descriptor.h
@@ -45,7 +45,7 @@ public:
     bool SingleStepping() const { return single_stepping; }
 
     bool operator == (const LocationDescriptor& o) const {
-        return std::tie(pc, fpcr, single_stepping) == std::tie(o.pc, o.fpcr, single_stepping);
+        return std::tie(pc, fpcr, single_stepping) == std::tie(o.pc, o.fpcr, o.single_stepping);
     }
 
     bool operator != (const LocationDescriptor& o) const {


### PR DESCRIPTION
Compare `single_stepping` with the other's value instead of comparing it
with the local value.